### PR TITLE
Add benchmarks

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,87 @@
+package raftmdb
+
+import (
+	"github.com/hashicorp/raft/bench"
+	"os"
+	"testing"
+)
+
+func BenchmarkMDBStore_FirstIndex(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.FirstIndex(b, store)
+}
+
+func BenchmarkMDBStore_LastIndex(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.LastIndex(b, store)
+}
+
+func BenchmarkMDBStore_GetLog(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.GetLog(b, store)
+}
+
+func BenchmarkMDBStore_StoreLog(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.StoreLog(b, store)
+}
+
+func BenchmarkMDBStore_StoreLogs(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.StoreLogs(b, store)
+}
+
+func BenchmarkMDBStore_DeleteRange(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.DeleteRange(b, store)
+}
+
+func BenchmarkMDBStore_Set(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.Set(b, store)
+}
+
+func BenchmarkMDBStore_Get(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.Get(b, store)
+}
+
+func BenchmarkMDBStore_SetUint64(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.SetUint64(b, store)
+}
+
+func BenchmarkMDBStore_GetUint64(b *testing.B) {
+	dir, store := MDBTestStore(b)
+	defer store.Close()
+	defer os.RemoveAll(dir)
+
+	raftbench.GetUint64(b, store)
+}

--- a/mdb_store_test.go
+++ b/mdb_store_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func MDBTestStore(t *testing.T) (string, *MDBStore) {
+func MDBTestStore(t testing.TB) (string, *MDBStore) {
 	// Create a test dir
 	dir, err := ioutil.TempDir("", "raft")
 	if err != nil {


### PR DESCRIPTION
Depends on hashicorp/raft#37. Adds calls in bench_test.go to benchmark raft-mdb.